### PR TITLE
Player control merge

### DIFF
--- a/game_client/Client.cpp
+++ b/game_client/Client.cpp
@@ -4,6 +4,7 @@
 
 #include "Client.h"
 #include "NetworkClient.h"
+#include "Message.hpp"
 
 Client * Client::CLIENT;
 
@@ -13,6 +14,9 @@ Client::Client(GLFWwindow * window, int argc, char **argv) {
 	// initalize mouse state
 	leftDown=middleDown=rightDown=false;
 	mouseX=mouseY=0;
+
+	// initialize keyboard state
+	setupKeyboardPresses();
 
 	// Initialize components
 	glfwGetWindowSize(windowHandle, &winX, &winY);
@@ -45,9 +49,11 @@ Client::~Client() {
 void Client::loop() {
 	while (!glfwWindowShouldClose(windowHandle)) {
 		//std::cout << "main looop" << std::endl;
+		sendKeyboardEvents();
 
 		// recieve the state from the server
 		currentGameState = netClient->getCurrentState();
+		//std::cout << currentGameState << std::endl;
 
 		scene->setState(currentGameState);
 
@@ -89,6 +95,24 @@ void Client::draw() {
 	glfwSwapBuffers(windowHandle);
 }
 
+/* Ideally there would be a single networking object that we would pass our 
+ events to and have it serializae and send them
+ */
+void Client::sendKeyboardEvents()
+{
+	if ((*keyPresses)[GLFW_KEY_W]) {
+        netClient->sendMessage(OPCODE_PLAYER_MOVE_UP);
+	}
+	if ((*keyPresses)[GLFW_KEY_A]) {
+        netClient->sendMessage(OPCODE_PLAYER_MOVE_LEFT);
+	}
+	if ((*keyPresses)[GLFW_KEY_S]) {
+        netClient->sendMessage(OPCODE_PLAYER_MOVE_DOWN);
+	}
+	if ((*keyPresses)[GLFW_KEY_D]) {
+		netClient->sendMessage(OPCODE_PLAYER_MOVE_RIGHT);
+	}
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -111,34 +135,22 @@ void Client::resize(GLFWwindow* window, int width, int height) {
 void Client::keyboard(GLFWwindow* window, int key, int scancode, int action, int mods)
 {
 	switch (key) {
-		case 0x1b:		// Escape
+		case GLFW_KEY_ESCAPE:		// Escape
 			quit();
 			break;
-		case 'r':
+		case GLFW_KEY_R:
 			reset();
 			break;
-		case GLFW_KEY_W: {
-			std::string w("w");
-			netClient->sendMessage(w);
-			break;
-		}
-		case GLFW_KEY_A: {
-			std::string a("a");
-			netClient->sendMessage(a);
-			break;
-		}
-		case GLFW_KEY_S: {
-			std::string s("s");
-			netClient->sendMessage(s);
-			break;
-		}
-		case GLFW_KEY_D: {
-			std::string d("d");
-			netClient->sendMessage(d);
-			break;
-		}
 		default:
-			break;
+			break;	
+	}
+
+	if (action == GLFW_PRESS && keyPresses->count((char)key) > 0) {
+		(*keyPresses)[key] = true;
+	}
+
+	if (action == GLFW_RELEASE && keyPresses->count((char)key) > 0) {
+		(*keyPresses)[key] = false;
 	}
 }
 
@@ -204,6 +216,16 @@ void Client::zoomScreen(GLFWwindow* window, double xoffset, double yoffset) {
 		cam->SetFOV(1.0f);
 	if (cam->GetFOV() >= 45.0f)
 		cam->SetFOV(45.0f);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void Client::setupKeyboardPresses()
+{
+	keyPresses = new std::unordered_map<int, bool>;
+	for (int c : keys) {
+		(*keyPresses)[c] = false;
+	}
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/game_client/Client.cpp
+++ b/game_client/Client.cpp
@@ -244,7 +244,7 @@ void Client::setupAudio() {
 
 ////////////////////////////////////////////////////////////////////////////////
 void Client::setupNetwork() {
-	netClient = new NetworkClient("localhost", "13");
+	netClient = new NetworkClient("localhost", "10032");
 	netClient->start();
 }
 

--- a/game_client/Client.h
+++ b/game_client/Client.h
@@ -28,11 +28,13 @@ public:
 	void loop(); // Loop will be the idling function of glut
 	void update(); // recalcuate the matrices
 	void draw(); // renders everything
+	void sendKeyboardEvents(); // Send keyboard events
 
 	void reset(); // reset scene ?
 	void quit(); // close window exit progmra ?
 	void setupAudio(); // setup audio engine
 	void setupNetwork(); // setup network client
+	void setupKeyboardPresses(); // setup keyboard handler
 
 	// Event handlers
 	void resize(GLFWwindow* window, int width, int height);
@@ -58,6 +60,7 @@ private:
 	Scene * scene;
 	Camera * cam;
 	CAudioEngine aEngine;
+	std::unordered_map<int, bool>* keyPresses;
 
 	NetworkClient *netClient;
 	GameState* currentGameState;

--- a/game_client/NetworkClient.cpp
+++ b/game_client/NetworkClient.cpp
@@ -1,4 +1,5 @@
 #include "NetworkClient.h"
+#include <boost/archive/text_oarchive.hpp>
 #include <iostream>
 
 
@@ -7,6 +8,7 @@ NetworkClient::NetworkClient(const char* host, const char* port) : socket(ioCont
 
     // Init queue with game state
     gameStates.push(new GameState());
+    gameStates.front()->init();
 
     boost::asio::ip::tcp::resolver resolver(ioContext);
     boost::asio::ip::tcp::resolver::results_type endpoints = resolver.resolve(host, port);
@@ -23,8 +25,12 @@ NetworkClient::NetworkClient(const char* host, const char* port) : socket(ioCont
                 boost::asio::placeholders::error,
                 boost::asio::placeholders::bytes_transferred));
                 */
-        socket.async_read_some(
+        /*socket.async_read_some(
             boost::asio::buffer(recvBuf),
+            boost::bind(&NetworkClient::handleReceive, this,
+                boost::asio::placeholders::error,
+                boost::asio::placeholders::bytes_transferred));*/
+        boost::asio::async_read_until(socket, readStreamBuf, CRLF,
             boost::bind(&NetworkClient::handleReceive, this,
                 boost::asio::placeholders::error,
                 boost::asio::placeholders::bytes_transferred));
@@ -34,14 +40,28 @@ NetworkClient::NetworkClient(const char* host, const char* port) : socket(ioCont
     }
 }
 
-void NetworkClient::sendMessage(std::string& msg) {
+void NetworkClient::sendMessage(int opCode) {
+    //std::cout << "sendMessage() :"<< opCode << std::endl;
+    Message msg(opCode);
     boost::asio::post(ioContext,
         boost::bind(&NetworkClient::doWrite, this, msg));
 }
 
-void NetworkClient::doWrite(std::string& msg) {
+void NetworkClient::doWrite(Message& msg) {
+    char buffer[max_length];
+
+    boost::iostreams::basic_array_sink<char> sr(buffer, max_length);
+    boost::iostreams::stream< boost::iostreams::basic_array_sink<char> > source(sr);
+
+    boost::archive::text_oarchive oa(source);
+
+    oa << msg;
+    source << CRLF;
+    source << '\0';
+
+    size_t send_size = std::strlen(buffer);
     socket.async_write_some(
-        boost::asio::buffer(msg.data(), msg.length()),
+        boost::asio::buffer(buffer, send_size),
         boost::bind(&NetworkClient::handleSend, this,
             boost::asio::placeholders::error,
             boost::asio::placeholders::bytes_transferred));
@@ -58,27 +78,39 @@ void NetworkClient::handleSend(const boost::system::error_code& error, size_t by
     if (error) {
         std::cerr << "Message Sent Error" << std::endl;
     }
-    std::cout << "Message Sent" << std::endl;
+    //std::cout << "Message Sent" << std::endl;
 }
 
 void NetworkClient::handleReceive(const boost::system::error_code& error, size_t bytes_transferred) {
     if (!error) {
+        std::ostringstream ss;
+        ss << &readStreamBuf;
+        std::string s = ss.str();
+        //std::cout << s << std::endl;
 
-        boost::iostreams::stream<boost::iostreams::array_source> is(recvBuf, 4096);
+        boost::iostreams::stream<boost::iostreams::array_source> is(s.data(), s.length());
+        
         boost::archive::text_iarchive ia(is);
-
         GameState* gameState = new GameState();
+
         ia >> (*gameState);
+        
+
         {
            boost::lock_guard<boost::recursive_mutex> lock(m_guard);
            gameStates.push(gameState);
         }
 
-       socket.async_read_some(
+        boost::asio::async_read_until(socket, readStreamBuf, CRLF,
+            boost::bind(&NetworkClient::handleReceive, this,
+                boost::asio::placeholders::error,
+                boost::asio::placeholders::bytes_transferred));
+
+       /*socket.async_read_some(
            boost::asio::buffer(recvBuf),
            boost::bind(&NetworkClient::handleReceive, this,
                boost::asio::placeholders::error,
-               boost::asio::placeholders::bytes_transferred));
+               boost::asio::placeholders::bytes_transferred)); */
     }
     else {
         socket.close();
@@ -95,7 +127,7 @@ GameState* NetworkClient::getCurrentState() {
         boost::lock_guard<boost::recursive_mutex> lock(m_guard);
            
         while (gameStates.size() > 1) {
-            std::cout << "gameStates.length() > 1" << std::endl;
+            //std::cout << "gameStates.length() > 1" << std::endl;
             retVal = gameStates.front();
             gameStates.pop();
             delete retVal;

--- a/game_client/NetworkClient.cpp
+++ b/game_client/NetworkClient.cpp
@@ -83,9 +83,11 @@ void NetworkClient::handleSend(const boost::system::error_code& error, size_t by
 
 void NetworkClient::handleReceive(const boost::system::error_code& error, size_t bytes_transferred) {
     if (!error) {
-        std::ostringstream ss;
-        ss << &readStreamBuf;
-        std::string s = ss.str();
+        std::string s{
+            boost::asio::buffers_begin(readStreamBuf.data()),
+            boost::asio::buffers_begin(readStreamBuf.data()) + bytes_transferred - 4 };
+        readStreamBuf.consume(bytes_transferred);
+
         //std::cout << s << std::endl;
 
         boost::iostreams::stream<boost::iostreams::array_source> is(s.data(), s.length());

--- a/game_client/NetworkClient.h
+++ b/game_client/NetworkClient.h
@@ -5,13 +5,14 @@
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/thread.hpp>
 #include "GameState.hpp"
+#include "Message.hpp"
 
 class NetworkClient {
 public:
     NetworkClient(const char* host, const char* port);
     ~NetworkClient();
 
-    void sendMessage(std::string& msg);
+    void sendMessage(int opCode);
     void handleSend(const boost::system::error_code& error, size_t bytes_transferred);
     void handleReceive(const boost::system::error_code& error, size_t bytes_transferred);
     void doClose();
@@ -22,13 +23,14 @@ public:
     void close();
 
 private:
-    void doWrite(std::string& msg);
+    void doWrite(Message& msg);
 
     boost::asio::io_context ioContext;
     boost::asio::ip::tcp::socket socket;
     boost::recursive_mutex m_guard;
     enum { max_length = 4096 };
     char sendBuf[max_length];
+    boost::asio::streambuf readStreamBuf;
     char recvBuf[max_length];
 
     std::queue<GameState*> gameStates;

--- a/game_client/Scene.cpp
+++ b/game_client/Scene.cpp
@@ -57,9 +57,9 @@ void Scene::update()
 		glm::mat4 mat4Transform(1.0f);
 
 		// Move
-		mat4Transform[3][0] = position->getX();
-		mat4Transform[3][1] = position->getY();
-		mat4Transform[3][2] = position->getZ();
+		mat4Transform[3][0] = position->x;
+		mat4Transform[3][1] = position->y;
+		mat4Transform[3][2] = position->z;
 		// Rotate
 		mat4Transform = getPoseFromDirection(direction->angle) * mat4Transform * RABBIT_SCALER;
 
@@ -73,9 +73,9 @@ void Scene::update()
 		glm::mat4 mat4Transform(1.0f);
 
 		// Move
-		mat4Transform[3][0] = position->getX();
-		mat4Transform[3][1] = position->getY();
-		mat4Transform[3][2] = position->getZ();
+		mat4Transform[3][0] = position->x;
+		mat4Transform[3][1] = position->y;
+		mat4Transform[3][2] = position->z;
 		
 		// Rotate
 		mat4Transform = getPoseFromDirection(direction->angle) * mat4Transform * PLAYER_SCALER;
@@ -84,9 +84,9 @@ void Scene::update()
 	}
 
 	tapTransform = glm::mat4(1.0);
-	tapTransform[3][0] = state->waterTap->position->getX();
-	tapTransform[3][1] = state->waterTap->position->getY();
-	tapTransform[3][2] = state->waterTap->position->getZ();
+	tapTransform[3][0] = state->waterTap->position->x;
+	tapTransform[3][1] = state->waterTap->position->y;
+	tapTransform[3][2] = state->waterTap->position->z;
 
 	tapTransform = tapTransform * getPoseFromDirection(state->waterTap->direction->angle) * WATER_TAP_SCALER;
 

--- a/game_server/GameServer.cpp
+++ b/game_server/GameServer.cpp
@@ -79,9 +79,10 @@ void ClientConnection::handleRead(const boost::system::error_code& error, size_t
         return;
     }
 
-    std::ostringstream ss;
-    ss << &readStreamBuf;
-    std::string s = ss.str();
+    std::string s{
+        boost::asio::buffers_begin(readStreamBuf.data()),
+        boost::asio::buffers_begin(readStreamBuf.data()) + bytes_transferred - 4 };
+    readStreamBuf.consume(bytes_transferred);
 
     //std::cout << s << std::endl;
     //std::cout << bytes_transferred << std::endl;

--- a/include/Animation.hpp
+++ b/include/Animation.hpp
@@ -3,6 +3,7 @@
 
 class Animation {
 public:
+    Animation() : animationType(0), animationFrame(0) {}
     Animation(int animationType, int animationFrame)
         : animationType(animationType),
           animationFrame(animationFrame) {}

--- a/include/Color.hpp
+++ b/include/Color.hpp
@@ -3,6 +3,7 @@
 
 class Color {
 public:
+    Color() : r(0), g(0), b(0) {}
     Color(float r, float g, float b): r(r), g(g), b(b) {}
 
     template<class Archive>

--- a/include/Direction.hpp
+++ b/include/Direction.hpp
@@ -3,6 +3,7 @@
 
 class Direction {
 public:
+    Direction() : angle(0) {}
     Direction(float angle): angle(angle) {}
 
     template<class Archive>

--- a/include/Message.hpp
+++ b/include/Message.hpp
@@ -1,0 +1,32 @@
+#ifndef _MESSAGE_H_
+#define _MESSAGE_H_
+
+
+#define CRLF "\r\n\r\n"
+
+#define OPCODE_NOP 0
+#define OPCODE_PLAYER_MOVE_UP 1
+#define OPCODE_PLAYER_MOVE_DOWN 2
+#define OPCODE_PLAYER_MOVE_LEFT 3
+#define OPCODE_PLAYER_MOVE_RIGHT 4
+#define OPCODE_PLAYER_INTERACT 5
+
+class Message {
+public:
+	Message() : opCode(OPCODE_NOP){}
+	Message(int op_code) : opCode(op_code) {}
+	
+	template <class Archive>
+	void serialize(Archive & ar, const unsigned int version) {
+		ar & opCode;
+	}
+
+	int getOpCode() {
+		return opCode;
+	}
+
+private:
+	int opCode;
+};
+
+#endif

--- a/include/Plant.hpp
+++ b/include/Plant.hpp
@@ -8,6 +8,8 @@
 
 class Plant {
 public:
+    Plant() : position(nullptr), direction(nullptr), animation(nullptr), range(nullptr) {}
+
     Plant(Position* position, Direction* direction,
           Animation* animation, TowerRange* range) {
         this->position = position;
@@ -19,10 +21,10 @@ public:
     template<class Archive>
     void serialize(Archive & ar, const unsigned int version)
     {
-        position->serialize(ar, version);
-        direction->serialize(ar, version);
-        animation->serialize(ar, version);
-        range->serialize(ar, version);
+        ar & position;
+        ar & direction;
+        ar & animation;
+        ar & range;
     }
 
     ~Plant() {

--- a/include/Player.hpp
+++ b/include/Player.hpp
@@ -8,6 +8,8 @@
 
 class Player {
 public:
+    Player() : position(nullptr), direction(nullptr), animation(nullptr), color(nullptr) {}
+
     Player(Position* position, Direction* direction,
            Animation* animation, Color* color, int playerId)
             : playerId(playerId) {
@@ -21,10 +23,10 @@ public:
     template<class Archive>
     void serialize(Archive & ar, const unsigned int version)
     {
-        position->serialize(ar, version);
-        direction->serialize(ar, version);
-        animation->serialize(ar, version);
-        color->serialize(ar, version);
+        ar & position;
+        ar & direction;
+        ar & animation;
+        ar & color;
         ar & playerId;
     }
 
@@ -33,13 +35,6 @@ public:
         delete direction;
         delete animation;
         delete color;
-    }
-
-    void updatePosition() {
-        position->update(
-            position->getX() + 1,
-            position->getY() + 1,
-            position->getZ() + 1);
     }
 
     Position* position; // Player position

--- a/include/Position.hpp
+++ b/include/Position.hpp
@@ -3,6 +3,7 @@
 
 class Position {
 public:
+    Position() : x(0), y(0), z(0) {}
     Position(float x, float y, float z): x(x), y(y), z(z) {}
 
     template<class Archive>
@@ -13,24 +14,6 @@ public:
         ar & z;
     }
 
-    void update(float x, float y, float z) {
-        this->x = x;
-        this->y = y;
-        this->z = z;
-    }
-
-    float getX() {
-        return x;
-    }
-
-    float getY() {
-        return y;
-    }
-    float getZ() {
-        return z;
-    }
-
-private:
     float x, y, z;
 };
 

--- a/include/SeedShack.hpp
+++ b/include/SeedShack.hpp
@@ -5,6 +5,8 @@
 
 class SeedShack {
 public:
+    SeedShack() : position(nullptr) {}
+
     SeedShack(Position* position) {
       this->position = position;
     }
@@ -12,7 +14,7 @@ public:
     template<class Archive>
     void serialize(Archive & ar, const unsigned int version)
     {
-        position->serialize(ar, version);
+        ar & position;
     }
 
     ~SeedShack() {

--- a/include/Tile.hpp
+++ b/include/Tile.hpp
@@ -6,9 +6,10 @@
 
 class Tile {
 public:
+    Tile() : position(nullptr), direction(nullptr) {}
+
     Tile(Position* position, int tileType, Direction* direction)
         : tileType(tileType) {
-
         this->tileType = tileType;
         this->position = position;
         this->direction = direction;
@@ -17,9 +18,9 @@ public:
     template<class Archive>
     void serialize(Archive & ar, const unsigned int version)
     {
-        position->serialize(ar, version);
+        ar & position;
         ar & tileType;
-        direction->serialize(ar, version);
+        ar & direction;
     }
 
     ~Tile() {

--- a/include/Tool.hpp
+++ b/include/Tool.hpp
@@ -5,6 +5,8 @@
 
 class Tool {
 public:
+    Tool() : position(nullptr) {}
+
     Tool(Position* position, int toolType, int heldBy)
         : toolType(toolType), heldBy(heldBy) {
 
@@ -14,7 +16,7 @@ public:
     template<class Archive>
     void serialize(Archive & ar, const unsigned int version)
     {
-        position->serialize(ar, version);
+        ar & position;
         ar & toolType;
         ar & heldBy;
     }
@@ -23,7 +25,6 @@ public:
         delete position;
     }
 
-private:
     Position* position; // Tool position
     int toolType; // e.g. watering can, hoe, etc
     int heldBy; // Either held by players 1 - 4 or not held (0)

--- a/include/TowerRange.hpp
+++ b/include/TowerRange.hpp
@@ -3,6 +3,7 @@
 
 class TowerRange {
 public:
+    TowerRange() : rangeDistance(0) {}
     TowerRange(float rangeDistance): rangeDistance(rangeDistance) {}
 
     template<class Archive>

--- a/include/WaterTap.hpp
+++ b/include/WaterTap.hpp
@@ -5,6 +5,8 @@
 
 class WaterTap {
 public:
+    WaterTap() : position(nullptr), direction(nullptr) {}
+    
     WaterTap(Position* position, Direction* direction) {
         this->position = position;
         this->direction = direction;
@@ -13,8 +15,8 @@ public:
     template<class Archive>
     void serialize(Archive & ar, const unsigned int version)
     {
-        position->serialize(ar, version);
-        direction->serialize(ar, version);
+        ar & position;
+        ar & direction;
     }
 
     ~WaterTap() {

--- a/include/Zombie.hpp
+++ b/include/Zombie.hpp
@@ -7,6 +7,8 @@
 
 class Zombie {
 public:
+    Zombie() : position(nullptr), direction(nullptr), animation(nullptr) {}
+
     Zombie(Position* position, Direction* direction, Animation* animation) {
         this->position = position;
         this->direction = direction;
@@ -16,9 +18,9 @@ public:
     template<class Archive>
     void serialize(Archive & ar, const unsigned int version)
     {
-        position->serialize(ar, version);
-        direction->serialize(ar, version);
-        animation->serialize(ar, version);
+        ar & position;
+        ar & direction;
+        ar & animation;
     }
 
     ~Zombie() {

--- a/network_client_test/network_client_test.vcxproj
+++ b/network_client_test/network_client_test.vcxproj
@@ -145,8 +145,6 @@
       <AdditionalLibraryDirectories>$(SolutionDir)lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
-  <ItemGroup>
-  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>


### PR DESCRIPTION
Player control merge.
Network team has tested that multiple clients connected to server and move around.

Please confirm the following things work before accept:

1. Run the server at 32 tick rate or lower (`.\game_server.exe 10032 32`)
2. Run multiple clients and move around to see if anything goes wrong

TODO:
- Graphics client should remove the player model when disconnected
- Player diagonal movement & face direction
- Move `Tile` class into `Ground` object
- `Tile` update  bug

After the merge the following branches will be deleted:
- `message_integration`
- `player-control`
- `player-control-merge`
